### PR TITLE
Update of node version to 14.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.1",
   "private": false,
   "engines": {
-    "node": "12.*"
+    "node": "14.*"
   },
   "scripts": {
     "start": "node server.js"


### PR DESCRIPTION
Node version should be updated from 12.x to 14.x in order to avoid errors while pushing apps to cloud foundry in IBM cloud.